### PR TITLE
Horizontal tabs fix & UI fix

### DIFF
--- a/horizontal_tabs.css
+++ b/horizontal_tabs.css
@@ -152,6 +152,19 @@ tab::after {
 	background: hsl(247, 10%, 28%);
 }
 
+#tabbrowser-arrowscrollbox-periphery {
+	margin: 0 !important;
+}
+
+.toolbarbutton-text {
+	/* NOTE: Remove this if you want to keep the "New tab" text */
+	display: none !important;
+}
+
 hbox#nav-bar-customization-target toolbarbutton.chromeclass-toolbar-additional:nth-of-type(1) {
 	padding-inline-start: var(--toolbar-start-end-padding) !important;
+}
+
+.tabbrowser-tab {
+	flex: 1 !important;
 }

--- a/horizontal_tabs.css
+++ b/horizontal_tabs.css
@@ -151,3 +151,7 @@ tab::after {
 	transform: translateY(-50%);
 	background: hsl(247, 10%, 28%);
 }
+
+hbox#nav-bar-customization-target toolbarbutton.chromeclass-toolbar-additional:nth-of-type(1) {
+	padding-inline-start: var(--toolbar-start-end-padding) !important;
+}


### PR DESCRIPTION
This PR fixes the following:
- Horizontal tabs on 1.0.1-a.19
- Missing padding on first toolbar button

Limitations:
- Currently selected tab uses full 200px width rather than having the same width as other tabs (check screenshot). Will try to fix this sometime soon in the future.

Before:
<img width="901" alt="Screenshot 2024-11-16 at 16 18 57" src="https://github.com/user-attachments/assets/1c7d7e32-2835-4c26-b5f6-e4a576d74364">

After:
<img width="901" alt="Screenshot 2024-11-16 at 16 19 15" src="https://github.com/user-attachments/assets/1f432dcc-eee2-4b63-9663-f0e839a3e610">