### PR TITLE
Fix vertical scrollbars appearing in v1.17.6b

### DIFF
--- a/horizontal_tabs.css
+++ b/horizontal_tabs.css
@@ -413,7 +413,12 @@ zen-workspace{
 /* comment out if want possible transformations*/
 }
 .zen-tabs-wrapper{
-   overflow:hidden;
+   overflow:hidden !important;
+}
+
+#zen-tabs-wrapper {
+   overflow-y: hidden !important;
+   overflow: hidden !important;
 }
 
 /*hide media buttons for now*/


### PR DESCRIPTION
Vertical scrollbar started appearing with version 1.17 (and possibley earlier). This adds an `overflow-y: hidden !important` to the `#zen-tabs-wrapper` element and adds `!important` to the `.zen-tabs-wrapper` class